### PR TITLE
Update check-for-existing-username-or-email-feature

### DIFF
--- a/controllers/user.js
+++ b/controllers/user.js
@@ -37,36 +37,59 @@ exports.create = (req, res) => {
 
   if (!req.body.dateOfBirth) {
     return res.status(400).send({
-      message: 'dateOfBirth!',
+      message: 'Require dateOfBirth!',
     });
   }
 
-  // Create an user
-  const user = new User({
-    //_id: Mongoose.Types.ObjectId(),
-    username: req.body.username,
-    password: req.body.password,
-    email: req.body.email,
-    firstName: req.body.firstName,
-    lastName: req.body.lastName,
-    dateOfBirth: req.body.dateOfBirth,
-    biography: req.body.biography || '',
-  });
-
-  // Save this user to database
-  user
-    .save()
-    .then((data) => {
-      res.send(data);
-    })
-    .catch((err) => {
-      console.log(err);
-      res.status(500).send({
-        message: 'Error when creating user!',
+  // Check for existing username or email ==================================
+  // Check for username
+  User.findOne({ email: req.body.email }).then((existedEmail) => {
+    // If the email is found
+    if (existedEmail) {
+      return res.status(400).send({
+        message: 'This email has been registered! Try another one!',
       });
-    });
+    }
+    // continue to check for username
+    else {
+      User.findOne({ username: req.body.username }).then((existedUname) => {
+        // If the username is found
+        if (existedUname) {
+          return res.status(400).send({
+            message: 'This username has been taken! Try another one!',
+          });
+        }
+        else {
+          // Then the username and email are good to be registered
+          // Create an user if all info is valid ==================================
+          const user = new User({
+            //_id: Mongoose.Types.ObjectId(),
+            username: req.body.username,
+            password: req.body.password,
+            email: req.body.email,
+            firstName: req.body.firstName,
+            lastName: req.body.lastName,
+            dateOfBirth: req.body.dateOfBirth,
+            biography: req.body.biography || '',
+          });
 
-  console.log('New user created! Yay');
+          // Save this user to database
+          user
+            .save()
+            .then((data) => {
+              res.send(data);
+            })
+            .catch((err) => {
+              console.log(err);
+              res.status(500).send({
+                message: 'Error when creating user!',
+              });
+            });
+          console.log('New user created! Yay');
+        }
+      });
+    }
+  });
 };
 
 // Update an user identified by the user's Id ==============================


### PR DESCRIPTION
Added checking for registered username/email when creating a new user account functionality. The backend now returns error type 400 when the new user registers for an existing username/email address. 
This current implementation attempts to check for the email address first, then the username. If you want to change it the other way around, please let me know!
